### PR TITLE
Fix for broken migration

### DIFF
--- a/database/migrations/2019_05_22_000000_update_category_column_to_array.php
+++ b/database/migrations/2019_05_22_000000_update_category_column_to_array.php
@@ -22,7 +22,7 @@ class UpdateCategoryColumnToArray extends Migration
         switch ($driver) {
             case 'sqlite': {
                 Schema::table('sendgrid_webhook_events', function (Blueprint $table) {
-                    $table->jsonb('categories')->default(json_encode([]))->index();
+                    $table->jsonb('categories')->nullable()->index();
                 });
 
                 DB::table('sendgrid_webhook_events')


### PR DESCRIPTION
Fixes the following error on fresh install

```
Syntax error or access violation: 1101 BLOB, TEXT, GEOMETRY or JSON column 'categories' can't have a default value
```